### PR TITLE
event、slideページにページネーションを実装 #57

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,6 +1,6 @@
 baseURL = 'https://rancher.jp/'
 title = "Rancher JP"
-author = "Katsuhiro Yamanaka"
+author = "Rancher JP Community"
 copyright = "Copyright © 2018 Rancher JP. All Rights Reserved."
 timeZone = 'Asia/Tokyo'
 defaultContentLanguage = "ja"
@@ -35,12 +35,13 @@ pygmentsCodefencesGuessSyntax = true
   socialShare = true
   delayDisqus = true
   showRelatedPosts = true
+  custom_css = ["css/custom.css"]
+  countPerPage = 6 # リストページの1ページあたりの記事数
+
 #  cusdisID = "XXX" # Get your App id from cusdis.com
 #  hideAuthor = true
 #  gcse = "012345678901234567b890:abcdefghijk" # Get your code from google.com/cse. Make sure to go to "Look and Feel" and change Layout to "Full Width" and Theme to "Classic"
 #  disclaimerText = "The opinions expressed herein are my own personal opinions and do not represent my employer’s view in any way."
-
-  custom_css = ["css/custom.css"]
 
 #[[Params.bigimg]]
 #  src = "img/triangle.jpg"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,11 +1,106 @@
 {{ define "main" }}
   <div class="container" role="main">
-    <div class="row">
-      <div class="col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1">
-        {{ with .Content }}
-            {{.}}
+
+    {{/* イベント一覧 */}}
+    {{ if eq .Section "event" }}
+      {{ $pages := where .Site.RegularPages "Section" "event" }}
+      {{ $paginator := .Paginate $pages .Site.Params.countPerPage }}
+
+      <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+        {{ range $paginator.Pages }}
+          <div class="col-xs-12 col-sm-6 col-md-4">
+            <div class="card h-100">
+              <div class="card-body">
+                <h4 class="card-title">
+                  <a class="stretched-link text-primary text-decoration-none" href="{{ .RelPermalink }}">{{ .Title }}</a>
+                </h4>
+                {{ if .Params.thumbnail }}
+                  <img class="img-fluid rounded p-2" src="{{ .Params.thumbnail }}" loading="lazy" alt="thumbnail for {{ .Title }}" style="height:180px;object-fit:cover;width:100%;">
+                {{ end }}
+                <p class="card-text mt-3">
+                  {{ with .Params.description }}{{ . | truncate 100 }}{{ else }}{{ .Summary | truncate 200 }}{{ end }}
+                </p>
+              </div>
+              <div class="card-footer">
+                <small class="text-muted">{{ .Date | time.Format ":date_long" }}</small>
+              </div>
+            </div>
+          </div>
         {{ end }}
       </div>
-    </div>
+
+      {{ if or $paginator.HasPrev $paginator.HasNext }}
+        <nav aria-label="Page navigation">
+          <ul class="pager main-pager">
+            {{ if $paginator.HasPrev }}
+              <li class="previous">
+                <a href="{{ $paginator.Prev.URL }}">&larr; {{ i18n "newerPosts" }}</a>
+              </li>
+            {{ end }}
+            {{ if $paginator.HasNext }}
+              <li class="next">
+                <a href="{{ $paginator.Next.URL }}">{{ i18n "olderPosts" }} &rarr;</a>
+              </li>
+            {{ end }}
+          </ul>
+        </nav>
+      {{ end }}
+
+    {{/* スライド一覧 */}}
+    {{ else if eq .Section "slide" }}
+      {{ $pages := where .Site.RegularPages "Section" "slide" }}
+      {{ $paginator := .Paginate $pages .Site.Params.countPerPage }}
+
+      <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+        {{ range $paginator.Pages }}
+          <div class="col-xs-12 col-sm-6 col-md-4">
+            <div class="card h-100">
+              <div class="card-body">
+                <h4 class="card-title">
+                  <a class="stretched-link text-primary text-decoration-none" href="{{ .RelPermalink }}">{{ .Title }}</a>
+                </h4>
+                {{ with .Params.slide_url }}
+                  <div class="mb-2">
+                    <iframe src="{{ . }}" frameborder="0" width="100%" height="200" allowfullscreen></iframe>
+                  </div>
+                {{ end }}
+                <p class="card-subtitle text-muted">
+                    by {{ .Params.Author }}
+                </p>
+              </div>
+              <div class="card-footer">
+                <small class="text-muted">{{ .Date | time.Format ":date_long" }}</small>
+              </div>
+            </div>
+          </div>
+        {{ end }}
+      </div>
+
+      {{ if or $paginator.HasPrev $paginator.HasNext }}
+        <nav aria-label="Page navigation">
+          <ul class="pager main-pager">
+            {{ if $paginator.HasPrev }}
+              <li class="previous">
+                <a href="{{ $paginator.Prev.URL }}">&larr; {{ i18n "newerPosts" }}</a>
+              </li>
+            {{ end }}
+            {{ if $paginator.HasNext }}
+              <li class="next">
+                <a href="{{ $paginator.Next.URL }}">{{ i18n "olderPosts" }} &rarr;</a>
+              </li>
+            {{ end }}
+          </ul>
+        </nav>
+      {{ end }}
+
+    {{/* デフォルト */}}
+    {{ else }}
+      <div class="row">
+          <div class="col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1">
+            {{ with .Content }}{{ . }}{{ end }}
+          </div>
+      </div>
+    {{ end }}
+
   </div>
 {{ end }}


### PR DESCRIPTION
イベントページ、スライドページにページネーションを実装しました。1ページの個数はconfig.tomlで指定するようにしています。（今のところページごとに違うコンテンツ数にする想定にはしていないので1つの変数です）

# 表示確認

## イベント１ページ目（1ページ：6個で確認時）

<img width="1217" height="937" alt="image" src="https://github.com/user-attachments/assets/00386e2a-c8e6-43fe-b139-f306eba233fc" />

## イベント２ページ目（1ページ：6個で確認時）

<img width="844" height="537" alt="image" src="https://github.com/user-attachments/assets/34c775cf-dfcd-4b09-82ed-a833829591bf" />

## スライド１ページ目（1ページ：3個で確認時）

<img width="1199" height="481" alt="image" src="https://github.com/user-attachments/assets/5a71adb2-05a4-4ff6-b440-7228f973a1e8" />

## スライド２ページ目（1ページ：3個で確認時）

<img width="892" height="493" alt="image" src="https://github.com/user-attachments/assets/9935f943-28b8-46a0-922c-50c98a5456e0" />
